### PR TITLE
Automatisation of tag creation when travis release package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ deploy:
     - master
     - "/[0-9]+\\.[0-9]+\\.[0-9]+/"
     node: '6.1'
+after_deploy: npm run tag

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "author": "Sacha STAFYNIAK",
   "main": "src/index.js",
   "scripts": {
+    "source-tag": "bash -c 'git tag --points-at=$(diff --old-line-format= --new-line-format= <(git rev-list --first-parent \"master\") <(git rev-list --first-parent \"HEAD\") | head -1)'",
+    "tag": "(git tag -d ${npm_package_version} || true) && (git push origin :${npm_package_version} || true) && (git tag -a ${npm_package_version} -m 'Release ${npm_package_version}' && git push --tags)",
     "test": "nyc --reporter=text-summary --reporter=lcov mocha",
     "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov > coverage/lcov.info && codecov"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stafyniaksacha/is-realy-primitive.git"
+    "url": "git+https://github.com/stafyniaksacha/is-really-primitive.git"
   },
   "keywords": [
     "checking",
@@ -21,9 +23,9 @@
   ],
   "license": "WTFPL",
   "bugs": {
-    "url": "https://github.com/stafyniaksacha/is-realy-primitive/issues"
+    "url": "https://github.com/stafyniaksacha/is-really-primitive/issues"
   },
-  "homepage": "https://github.com/stafyniaksacha/is-realy-primitive#readme",
+  "homepage": "https://github.com/stafyniaksacha/is-really-primitive#readme",
   "dependencies": {},
   "devDependencies": {
     "codecov": "^1.0.1",


### PR DESCRIPTION
## Description

add `npm run source-tag` which will output source tag associated to current HEAD 
add `npm run tag` which will create an annotated tag associated to the current version in package.json